### PR TITLE
Fix pagination parameter in gelbooru.rs

### DIFF
--- a/src/client/gelbooru.rs
+++ b/src/client/gelbooru.rs
@@ -130,7 +130,7 @@ impl Client for GelbooruClient {
                     ("q", "index"),
                     ("limit", Buffer::new().format(builder.limit)),
                     ("tags", &tag_string),
-                    ("pid", Buffer::new().format(builder.limit * page)),
+                    ("pid", Buffer::new().format(page)),
                     ("json", "1"),
                 ],
             )


### PR DESCRIPTION
A page number is not working the same as in danbooru, it is not an offset of limit * page it is individual parameter.
So for the example if we use 1 there we will get to 43 page on site